### PR TITLE
Updated ip address lookup to work with Docker 1.3.2

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -55,7 +55,7 @@ docker rm docker-dns;
 
 sleep 3;
 
-CMD="docker run -d -t --privileged=true -h ${HOST} --name docker-dns ${BINDARG} -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}/log:/var/log/supervisor ${CONFARG}";
+CMD="docker run -d -t --privileged=true -h ${HOST} --name docker-dns ${BINDARG} -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}/log:/var/log/supervisor ${CONFARG} $NAME";
 
 echo $CMD;
 

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+NAME=bfoote/docker-dns
 DOCKERBRIDGEIP=$(ip addr show dev docker0 | awk -F'[ /]*' '/inet /{print $3}');
 
 
@@ -54,7 +55,7 @@ docker rm docker-dns;
 
 sleep 3;
 
-CMD="docker run -d -t --privileged=true -h ${HOST} --name docker-dns ${BINDARG} -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}/log:/var/log/supervisor ${CONFARG} bfoote/docker-dns ";
+CMD="docker run -d -t --privileged=true -h ${HOST} --name docker-dns ${BINDARG} -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}/log:/var/log/supervisor ${CONFARG}";
 
 echo $CMD;
 
@@ -63,7 +64,7 @@ UUID=$($CMD);
 #echo $UUID;
 
 cat <<EOF
-    
+
     try this out to test if it worked:
 
        dig -t SRV \* @172.17.42.1
@@ -74,7 +75,7 @@ cat <<EOF
 
     please send pulls and patches, especially to update
     the config/etc-services file
-    
+
     Thanks!
 
     ben

--- a/lib/container-inspect.js
+++ b/lib/container-inspect.js
@@ -58,7 +58,7 @@ proto.gatherInfo = function(cb) {
 
 		
 		// discover services and their port bindings
-		var iHPb = self.insp.HostConfig.PortBindings;
+		var iHPb = self.insp.NetworkSettings.Ports;
 		if (!iHPb) {
 			self.log.debug(self.uuid12, "no portbindings found");
 //			console.log(insp);
@@ -251,7 +251,8 @@ proto.getIps = function() {
 	};
 	
 	try {
-		var iHp = self.insp.HostConfig.PortBindings;
+		var iHp = self.insp.NetworkSettings.Ports;
+		self.log.debug("iHp", iHp);
 		if (iHp
 				&& Object.keys(iHp).length > 0
 				&& iHp[Object.keys(iHp)[0]]
@@ -261,7 +262,7 @@ proto.getIps = function() {
 		) {
 			var hostboundip = iHp[Object
 			                      .keys(iHp)[0]][0].HostIp;
-			// console.log('getip ip: ', ip);
+			self.log.debug('getip ip: ', hostboundip);
 			if (hostboundip === '0.0.0.0') {
 				ips.exposed = self.config.publicip;
 			} else if (hostboundip !== ips.internal) {
@@ -272,5 +273,5 @@ proto.getIps = function() {
 		self.log.error('portbinding publicip lookup failed', err);
 	}
 	self.ips = ips;
-	self.log.debug("ip ", self.ips);
+	self.log.debug("ips ", self.ips);
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "engineStrict": true,
   "dependencies": {
     "async": "~0.9.0",
-    "dockerode": "~2.0.1",
+    "dockerode": "~2.0.6",
     "lazy": "~1.0.11",
     "lodash": "~2.4.1",
     "minimist": "~0.2.0",


### PR DESCRIPTION
Those fixes allowed me to make this work for Docker 1.3.2 on CentOS 6.6:

If using `self.insp.NetworkSettings.Ports` break another version, the code should smart enough to use either sources.
